### PR TITLE
Correção da configuração de segurança e configuração do banco H2

### DIFF
--- a/src/main/kotlin/com/example/kotlinspring/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/kotlinspring/config/SecurityConfig.kt
@@ -35,7 +35,8 @@ class SecurityConfig(
             .csrf().disable()
 
             .authorizeRequests { request -> run{
-                request.antMatchers(HttpMethod.POST, "api/v1/auth/**").permitAll()
+                request.antMatchers(HttpMethod.POST,"/api/v1/auth/**").permitAll()
+                request.antMatchers("/banco/**").permitAll() // Deixa o banco brinca
                 request.anyRequest().authenticated()
             } }
 
@@ -50,6 +51,9 @@ class SecurityConfig(
             .authenticationProvider(authenticationProvider())
             .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
 
+        // Usar somente em testes!
+        // desativando frameOptions do header no momento de devolver a resposta (Correção H2)
+        http.headers().frameOptions().disable();
         return http.build()
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,9 +7,13 @@ security.sign_up_url=api/login
 
 spring.datasource.url= jdbc:h2:mem:testdb
 spring.datasource.username= sa
-spring.datasource.password=password
+# Como H2 está sendo usado mais para teste, não existe necessidade de definir senha
+spring.datasource.password=
 spring.datasource.driverClassName= org.h2.Driver
 spring.jpa.database-platform= org.hibernate.dialect.H2Dialect
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/banco
 
 
 


### PR DESCRIPTION
Correção do problema ao tentar acessar end-points que deveria ser possível acessar, assim como a configuração do banco h2 para que o console seja ativado e acessível mesmo utilizando o spring security.